### PR TITLE
Don't run createrepo on repodata directories

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Shell scripts should have LF line endings.
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ You could choose to use a random port on the host, in particular if port 80 is a
 
 * You can have any number of subdirectories, each as their own YUM repo. For example, if you use `-v /tmp/yum-repo:/usr/share/nginx/html`, if subdirectories with RPM files exist underneath `/tmp/yum-repo`, then when the Docker container starts it will recursively visit each subdirectory, and run the `createrepo` command which generates the YUM metadata.
 * The webserver does not have a default page, and will return an HTTP 403 Forbidden if you browse to the root path, rather than listing the files.
+* If zero RPM files are found, the container will stop running with an error.
 
 ## How to build the image
 
-`docker build -t simple-yum-repo-webserver`
+`docker build -t simple-yum-repo-webserver .`

--- a/recursively-createrepo.sh
+++ b/recursively-createrepo.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
-# Recursively runs createrepo, starting from the base of the mounted volume.
-for directory in `find /usr/share/nginx/html -type d`; do
-  echo Running createrepo ${directory}
-  createrepo ${directory}
-done
+FOUND_RPMS=$(find /usr/share/nginx/html -type f -name '*.rpm' -print -quit)
 
+if test -n "$FOUND_RPMS"
+then
+  # For each non-repodata directory, run createrepo
+  for directory in `find /usr/share/nginx/html -type d -not -path "*/repodata"`; do
+    echo "Running createrepo on: ${directory}"
+    createrepo ${directory}
+  done
+else
+  echo "No RPM files were found; was the correct directory mounted into Docker?"
+  exit 1
+fi


### PR DESCRIPTION
Also verify that RPM files exist in the mounted directory.

Fixes #1.

Tested:
* Running the container without mounting a directory. It correctly exits with an error message.
* Running the container with a mounted directory tree where RPMs exist in multiple directories of the tree. The repodata directories were created as expected.
* Re-running the container on a previously mounted directory tree that already contained YUM repodata. The repodata directories were correctly excluded, and the problem in #1 of nested repodata directories is no longer reproduced.